### PR TITLE
[16.0][FIX] stock_picking_delivery_link: inherit _set_delivery_package_type without parameter batch_pack

### DIFF
--- a/stock_picking_delivery_link/README.rst
+++ b/stock_picking_delivery_link/README.rst
@@ -60,6 +60,7 @@ Contributors
 * Sébastien Alix <sebastien.alix@camptocamp.com>
 * Fernando La Chica - GreenIce <fernandolachica@gmail.com>
 * Hughes Damry <hughes.damry@acsone.eu>
+* Tris Doan <tridm@trobz.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_picking_delivery_link/models/stock_picking.py
+++ b/stock_picking_delivery_link/models/stock_picking.py
@@ -55,7 +55,7 @@ class StockPicking(models.Model):
         else:
             return res
 
-    def _set_delivery_package_type(self):
+    def _set_delivery_package_type(self, batch_pack=False):
         self.ensure_one()
         res = super()._set_delivery_package_type()
         context = dict(

--- a/stock_picking_delivery_link/readme/CONTRIBUTORS.rst
+++ b/stock_picking_delivery_link/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Sébastien Alix <sebastien.alix@camptocamp.com>
 * Fernando La Chica - GreenIce <fernandolachica@gmail.com>
 * Hughes Damry <hughes.damry@acsone.eu>
+* Tris Doan <tridm@trobz.com>

--- a/stock_picking_delivery_link/static/description/index.html
+++ b/stock_picking_delivery_link/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -406,6 +405,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Sébastien Alix &lt;<a class="reference external" href="mailto:sebastien.alix&#64;camptocamp.com">sebastien.alix&#64;camptocamp.com</a>&gt;</li>
 <li>Fernando La Chica - GreenIce &lt;<a class="reference external" href="mailto:fernandolachica&#64;gmail.com">fernandolachica&#64;gmail.com</a>&gt;</li>
 <li>Hughes Damry &lt;<a class="reference external" href="mailto:hughes.damry&#64;acsone.eu">hughes.damry&#64;acsone.eu</a>&gt;</li>
+<li>Tris Doan &lt;<a class="reference external" href="mailto:tridm&#64;trobz.com">tridm&#64;trobz.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
### Context:

- `_set_delivery_package_type`: is inherited but without parameter batch_pack=False
-> cause error: 

> TypeError: StockPicking._set_delivery_package_type() got an unexpected keyword argument 'batch_pack'